### PR TITLE
Fix bug in draw_line() if y2 < y1

### DIFF
--- a/src/UNIT_GLASS.cpp
+++ b/src/UNIT_GLASS.cpp
@@ -89,7 +89,7 @@ void UNIT_GLASS::draw_point(uint8_t x, uint8_t y, uint8_t mode) {
 void UNIT_GLASS::draw_line(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
                            uint8_t mode) {
     uint8_t data[5];
-    if(y2 < y1) {
+    if (y2 < y1) {
         data[0] = x2;
         data[1] = y2;
         data[2] = x1;

--- a/src/UNIT_GLASS.cpp
+++ b/src/UNIT_GLASS.cpp
@@ -89,11 +89,19 @@ void UNIT_GLASS::draw_point(uint8_t x, uint8_t y, uint8_t mode) {
 void UNIT_GLASS::draw_line(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
                            uint8_t mode) {
     uint8_t data[5];
-
-    data[0] = x1;
-    data[1] = y1;
-    data[2] = x2;
-    data[3] = y2;
+    if(y2 < y1) {
+        data[0] = x2;
+        data[1] = y2;
+        data[2] = x1;
+        data[3] = y1;
+    }
+    else
+    {
+        data[0] = x1;
+        data[1] = y1;
+        data[2] = x2;
+        data[3] = y2;
+    }
     data[4] = mode;
     writeBytes(_addr, GLASS_DRAW_LINE_REG, data, 5);
 }

--- a/src/UNIT_GLASS.cpp
+++ b/src/UNIT_GLASS.cpp
@@ -94,9 +94,7 @@ void UNIT_GLASS::draw_line(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
         data[1] = y2;
         data[2] = x1;
         data[3] = y1;
-    }
-    else
-    {
+    } else {
         data[0] = x1;
         data[1] = y1;
         data[2] = x2;


### PR DESCRIPTION
GitHub Gist is here https://gist.github.com/armel/c45ab7e2632b6e6788c090074ae21cce for a bug example. With Glass Unit, there is a bug with draw_line(x1, y1, x2, y2, mode).
If y2 < y1, we obtain an horizontal line 🤔 Hope this help.